### PR TITLE
Make gem compatible with Rails 5 and decent_exposure 3

### DIFF
--- a/app/controllers/carrierwave_ios_rails/api/v1/api_controller.rb
+++ b/app/controllers/carrierwave_ios_rails/api/v1/api_controller.rb
@@ -4,9 +4,9 @@ module CarrierwaveIosRails
 
     rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
-    decent_configuration do
-      strategy DecentExposure::StrongParametersStrategy
-    end
+    #decent_configuration do
+    #  strategy DecentExposure::StrongParametersStrategy
+    #end
 
     private
 

--- a/carrierwave_ios_rails.gemspec
+++ b/carrierwave_ios_rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", ">= 4.0.0", "<= 4.2.0"
+  s.add_dependency "rails", ">= 4.0.0", "<= 5.1.0"
   s.add_dependency "carrierwave"
   s.add_dependency "decent_exposure"
   s.add_dependency "responders"


### PR DESCRIPTION
Gem uses decent_exposure gem which has recently been upgraded from version 2 to version 3. The upgrade breaks the carrierwave-ios-rails gem due to changes in decent_exposure API. This PR fixes this and also updates the gemspec dependency to rails 5.